### PR TITLE
fix: dylib parsing

### DIFF
--- a/spec/factory.spec.ts
+++ b/spec/factory.spec.ts
@@ -82,4 +82,25 @@ describe('createMachoFiles', () => {
             expect(expected.get(uuid)).toEqual(path);
         }
     });
+
+  describe("isFatOrMacho", () => {
+    it("should return true for fat file", async () =>
+      expectAsync(
+        isFatOrMacho(
+          "spec/support/bugsplat-ios.app/Frameworks/bugsplat.framework/HockeySDKResources.bundle/Contents/MacOS/HockeySDKResources"
+        )
+      ).toBeResolvedTo(true));
+
+    it("should return true for macho file", async () =>
+      expectAsync(
+        isFatOrMacho(
+          "spec/support/bugsplat.app.dSYM/Contents/Resources/DWARF/bugsplat"
+        )
+      ).toBeResolvedTo(true));
+
+    it("should return true for dylib file", async () =>
+      expectAsync(isFatOrMacho("spec/support/libggcurl.dylib")).toBeResolvedTo(
+        true
+      ));
+  });
 });

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -93,6 +93,6 @@ async function getUniqueMachoFiles(machoFiles: Array<MachoFile>): Promise<Array<
     return Array.from(uniqueMachoFiles.values());
 }
 
-async function isFatOrMacho(path: string): Promise<boolean> {
-    return !extname(path) && (await MachoFile.isMacho(path) || await FatFile.isFat(path));
+export async function isFatOrMacho(path: string): Promise<boolean> {
+    return (await MachoFile.isMacho(path) || await FatFile.isFat(path));
 }


### PR DESCRIPTION
### Description

I thought that DWARF symbols were all files with no extension. I thought wrong, dylib has an extension. There's no harm in removing this check, we just might try and read/parse more files than we did before, but the operation is wrapped in a catch.

### Checklist

- [x] Tested manually
- [x] Unit tests pass with no errors or warnings
- [x] Documentation updated (if applicable)
- [x] Reviewed by at least 1 other contributor
